### PR TITLE
SearchEnabledVC fix

### DIFF
--- a/DiscountsAndPromotionsApp/Navigation/Coordinator.swift
+++ b/DiscountsAndPromotionsApp/Navigation/Coordinator.swift
@@ -11,5 +11,6 @@ protocol Coordinator: AnyObject {
 extension Coordinator {
     func navigateBack() {
         navigationController.popViewController(animated: true)
+        navigationController.navigationBar.isHidden = true
     }
 }

--- a/DiscountsAndPromotionsApp/Navigation/ScanFlowCoordinator.swift
+++ b/DiscountsAndPromotionsApp/Navigation/ScanFlowCoordinator.swift
@@ -5,18 +5,17 @@ final class ScanFlowCoordinator: Coordinator {
     var navigationController: UINavigationController
     // вынес из функции чтобы вьюконтроллер не исчезал из памяти и кнопка работала
     private var scanVC: ScanViewController?
-
     private var productService: ProductNetworkServiceProtocol
 
     init(navigationController: UINavigationController,
          productService: ProductNetworkServiceProtocol) {
         self.navigationController = navigationController
         self.productService = productService
+
+//        self.navigationController.navigationBar.isHidden = true
     }
 
-    func start() {
-
-    }
+    func start() { }
 
     func showScanner() {
         let captureSessionController = ScanCaptureSessionController(coordinator: self)

--- a/DiscountsAndPromotionsApp/UI/NavigationBar/SearchEnabledViewController.swift
+++ b/DiscountsAndPromotionsApp/UI/NavigationBar/SearchEnabledViewController.swift
@@ -16,6 +16,10 @@ class SearchEnabledViewController: UIViewController {
         return backButton
     }()
 
+    private lazy var backAction: () -> Void = { [weak self] in
+        self?.navigationController?.popViewController(animated: true)
+    }
+
     override var preferredStatusBarStyle: UIStatusBarStyle {
         return .lightContent
     }
@@ -29,6 +33,10 @@ class SearchEnabledViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         navigationController?.navigationBar.isHidden = false
+    }
+
+    func setBackAction(action: @escaping () -> Void) {
+        backAction = action
     }
 
     private func setupSearchBar() {
@@ -62,8 +70,7 @@ class SearchEnabledViewController: UIViewController {
 
     @objc
     private func defaultBackAction() {
-        // не уверен стоит ли в протокол отдельный координатор добавлять и везде прокидывать?
-        navigationController?.popViewController(animated: true)
+        backAction()
     }
 }
 

--- a/DiscountsAndPromotionsApp/UI/ScanFlow/Views/EmptyScanResultViewController.swift
+++ b/DiscountsAndPromotionsApp/UI/ScanFlow/Views/EmptyScanResultViewController.swift
@@ -11,23 +11,13 @@ final class EmptyScanResultViewController: ScannerEnabledViewController {
     init() {
         self.emptyResultView = EmptyOnScreenView(state: .noResult)
         super.init(nibName: nil, bundle: nil)
-        setupView()
+        self.hidesBottomBarWhenPushed = true
+        setupUI()
         setupBindings()
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        self.navigationController?.tabBarController?.tabBar.isHidden = true
-
-    }
-
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        self.navigationController?.tabBarController?.tabBar.isHidden = false
     }
 
     private func setupBindings() {
@@ -39,9 +29,12 @@ final class EmptyScanResultViewController: ScannerEnabledViewController {
             .store(in: &cancellables)
     }
 
-    private func setupView() {
-        view.addSubview(emptyResultView)
+    private func setupUI() {
+        setBackAction { [weak self] in
+            self?.coordinator?.navigateBack()
+        }
 
+        view.addSubview(emptyResultView)
         emptyResultView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
         }

--- a/DiscountsAndPromotionsApp/UI/ScanFlow/Views/ScanViewController.swift
+++ b/DiscountsAndPromotionsApp/UI/ScanFlow/Views/ScanViewController.swift
@@ -325,7 +325,6 @@ final class ScanViewController: UIViewController {
     }
 }
 
-// MARK: - Button selectors
 extension ScanViewController {
     private func formatPlaceholder(_ placeholder: String) -> NSAttributedString {
         var dotIndex = placeholder.filter { $0.isWholeNumber }.count
@@ -347,6 +346,8 @@ extension ScanViewController {
 
         return formattedPlaceholderNumbers
     }
+
+    // MARK: - Button selectors
 
     @objc
     private func toggleFlash() {


### PR DESCRIPTION
Допилил немного базовый вьюконтроллер с поиском и кнопкой назад чтобы можно было в нее пост-фактум кинуть метод из координатора. Потому что эти переходы назад заставляют пустой скрытый навбар скан контроллера показаться вновь иначе. Или как вариант его можно сразу с координатором сдружить жестко но ка кбудто менее гибко. Еще мне кажется с нашел где экран для пустых результатов чуть сократить.